### PR TITLE
Update a typo in default.cfg

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -43,8 +43,8 @@ ROUTER_DB = {
       'target': 'ar71xx',
       'dualband': False
     },
-    'tl-wr1034nd' : {
-      'name': 'TP-Link WR1034ND',
+    'tl-wr1043nd' : {
+      'name': 'TP-Link WR1043ND',
       'img': 'img/router/tl-wr1043nd.jpg',
       'target': 'ar71xx',
       'dualband': False


### PR DESCRIPTION
In line 46 and down there is a typo i think, the Router is called 1043ND not 1034ND
