### PR TITLE
Update select_router.html - Erklärung zu N/ND-Modellen und Versionsnummer

### DIFF
--- a/app/templates/wizard/select_router.html
+++ b/app/templates/wizard/select_router.html
@@ -17,7 +17,11 @@ Router auswählen
           hast, kannst du ein beliebiges Modell wählen und die weiteren
           Angaben zur Firmware ignorieren.
           </p>
-
+          <p>TP-Link-Router, deren Modellname auf ND endet, sollten mit den
+          ansonsten gleichnamigen, auf N endenden, kompatibel sein
+          (das D verweist nur auf abnehmbare Antennen). Bei der 
+          TP-Link-Versionsnummer kommt es nur auf die erste Stelle an.
+          </p>
           <p>
           <strong>Anmerkung:</strong>
           Die folgende Liste ist <strong>nicht</strong> als Liste

--- a/app/templates/wizard/select_router.html
+++ b/app/templates/wizard/select_router.html
@@ -17,11 +17,13 @@ Router auswählen
           hast, kannst du ein beliebiges Modell wählen und die weiteren
           Angaben zur Firmware ignorieren.
           </p>
+          
           <p>TP-Link-Router, deren Modellname auf ND endet, sollten mit den
           ansonsten gleichnamigen, auf N endenden, kompatibel sein
           (das D verweist nur auf abnehmbare Antennen). Bei der 
           TP-Link-Versionsnummer kommt es nur auf die erste Stelle an.
           </p>
+          
           <p>
           <strong>Anmerkung:</strong>
           Die folgende Liste ist <strong>nicht</strong> als Liste


### PR DESCRIPTION
Der 2. Versuch, jetzt hoffentlich gegen das korrekte repository
Der 1. Versuch: https://github.com/sys3175/config.berlin.freifunk.net/pull/1