### PR TITLE
Remove links to router-wizard

### DIFF
--- a/app/templates/destroy_form.html
+++ b/app/templates/destroy_form.html
@@ -30,7 +30,7 @@ Antrag löschen
       <div class="row">
         <div class="col-md-12">
           <p class="text-center">
-            <a href="{{url_for('wizard.wizard_select_router')}}">zurück zur Startseite</a>
+            <a href="{{url_for('main.index')}}">zurück zur Startseite</a>
           </p>
         </div>
       </div>

--- a/app/templates/destroy_success.html
+++ b/app/templates/destroy_success.html
@@ -11,7 +11,7 @@ Löschung erfolgreich
           </p>
 
           <p class="text-center">
-            <a href="{{url_for('wizard.wizard_select_router')}}">zur Startseite</a>
+            <a href="{{url_for('main.index')}}">zur Startseite</a>
           </p>
         </div>
       </div>

--- a/app/templates/summary/form.html
+++ b/app/templates/summary/form.html
@@ -27,7 +27,7 @@ Auflistung deiner IPs beantragen
       <div class="row">
         <div class="col-md-12">
           <p class="text-center">
-            <a href="{{url_for('wizard.wizard_select_router')}}">zurück zur Startseite</a>
+            <a href="{{url_for('main.index')}}">zurück zur Startseite</a>
           </p>
         </div>
       </div>

--- a/app/templates/summary/success.html
+++ b/app/templates/summary/success.html
@@ -13,7 +13,7 @@ Email gesendet
           </p>
 
           <p class="text-center">
-            <a href="{{url_for('wizard.wizard_select_router')}}">zur Startseite</a>
+            <a href="{{url_for('main.index')}}">zur Startseite</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
in https://github.com/freifunk-berlin/config.berlin.freifunk.net/commit/868aa004cc352342f0ee6eb0711c5a7a981ff14c we deactivated the router-wizard. This PR removes some / all links to the wizard, this is often referenced by the "zurück zur Startseite"